### PR TITLE
Gen_netlist script created. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,3 +161,8 @@ test-all: ## Run all cocotb testbenches via pytest
 clean-sim: ## Remove all sim-build dirs in cocotb
 	cd cocotb; rm -r sim_build*
 .PHONY: clean-sim
+
+# generate netlists for all top-level modules
+gen-netlists: ## Generate netlists for all top-level modules
+	PDK_ROOT=${PDK_ROOT} PDK=${PDK} python3 scripts/gen_netlists.py
+.PHONY: gen-netlists

--- a/cocotb/cache_controller_test.py
+++ b/cocotb/cache_controller_test.py
@@ -726,13 +726,28 @@ async def miss_emits_busrd_and_write_hit_upgrade(dut):
 if __name__ == "__main__":
     root = Path(__file__).resolve().parent.parent
     runner = get_runner("icarus")
-    runner.build(
-        sources=[
+
+    sources = []
+    if gl:
+        pdk_lib = os.path.join(
+            pdk_root, 
+            pdk, 
+            "libs.ref", 
+            scl, 
+            "verilog"
+        )
+        sources += [proj_path / "../src/netlists/housekeeping_top.nl.v"]
+        sources += [os.path.join(pdk_lib, f) for f in [f"{scl}.v", f"primitives.v"]]
+    else:
+        sources += [
             root / "src/msi_protocol/msi_protocol.sv",
             root / "src/cache/cache.sv",
             root / "src/mem_ctrl/mem512x32.sv",
             root / "src/cache/cache_controller.sv",
-        ],
+        ]
+
+    runner.build(
+        sources=sources,
         hdl_toplevel="cache_controller",
         build_dir=str(Path(__file__).resolve().parent / "sim_build" / "cache_controller"),
         always=True,

--- a/cocotb/housekeeping_tb.py
+++ b/cocotb/housekeeping_tb.py
@@ -288,11 +288,23 @@ async def test_boot_after_passthrough(dut):
 def boot_ctrl_runner():
     proj_path = Path(__file__).resolve().parent
 
-    sources = [
-        proj_path / "../src/housekeeping/spi_engine.sv",
-        proj_path / "../src/housekeeping/boot_fsm.sv",
-        proj_path / "../src/housekeeping/housekeeping_top.sv"
-    ]
+    sources = []
+    if gl:
+        pdk_lib = os.path.join(
+            pdk_root, 
+            pdk, 
+            "libs.ref", 
+            scl, 
+            "verilog"
+        )
+        sources += [proj_path / f"../src/netlists/{hdl_toplevel}.nl.v"]
+        sources += [os.path.join(pdk_lib, f) for f in [f"{scl}.v", f"primitives.v"]]
+    else:
+        sources = [
+            proj_path / "../src/housekeeping/spi_engine.sv",
+            proj_path / "../src/housekeeping/boot_fsm.sv",
+            proj_path / "../src/housekeeping/housekeeping_top.sv"
+        ]
 
     build_args = []
     if sim == "icarus":

--- a/cocotb/mem_test.py
+++ b/cocotb/mem_test.py
@@ -111,14 +111,27 @@ async def test_mem_ctrl_against_golden(dut):
 def mem_ctrl_runner():
     proj_path = Path(__file__).resolve().parent
 
-    sources = [
-        # SRAM macro
-        Path(pdk_root) / pdk / "libs.ref/gf180mcu_fd_ip_sram/verilog/gf180mcu_fd_ip_sram__sram512x8m8wm1.v",
-        # SRAM bank 
-        proj_path / "../src/mem_ctrl/main_memory/mem512x32.sv",
-        # memory with sram bank muxing
-        proj_path / "../src/mem_ctrl/main_memory/mem2048x32.sv"
-    ]
+    sources = []
+    if gl:
+        pdk_lib = os.path.join(
+            pdk_root, 
+            pdk, 
+            "libs.ref", 
+            scl, 
+            "verilog"
+        )
+        sources += [proj_path / "../src/netlists/mem_ctrl_2048x32.nl.v"]
+        sources += [os.path.join(pdk_lib, f) for f in [f"{scl}.v", f"primitives.v"]]
+        sources += [Path(pdk_root) / pdk / "libs.ref/gf180mcu_fd_ip_sram/verilog/gf180mcu_fd_ip_sram__sram512x8m8wm1.v"]
+    else:
+        sources = [
+            # SRAM macro
+            Path(pdk_root) / pdk / "libs.ref/gf180mcu_fd_ip_sram/verilog/gf180mcu_fd_ip_sram__sram512x8m8wm1.v",
+            # SRAM bank 
+            proj_path / "../src/mem_ctrl/main_memory/mem512x32.sv",
+            # memory with sram bank muxing
+            proj_path / "../src/mem_ctrl/main_memory/mem2048x32.sv"
+        ]
 
     build_args = []
     if sim == "icarus":

--- a/cocotb/sp_handler_tb.py
+++ b/cocotb/sp_handler_tb.py
@@ -137,10 +137,22 @@ async def thorough_mmio_test(dut):
 def sp_handler_tb_runner():
     proj_path = Path(__file__).resolve().parent
 
-    sources = [
-        proj_path / "../src/mmio/mmio.sv",
-        proj_path / "../src/mmio/sp_addr_handler.sv"
-    ]
+    sources = []
+    if gl:
+        pdk_lib = os.path.join(
+            pdk_root, 
+            pdk, 
+            "libs.ref", 
+            scl, 
+            "verilog"
+        )
+        sources += [proj_path / f"../src/netlists/{hdl_toplevel}.nl.v"]
+        sources += [os.path.join(pdk_lib, f) for f in [f"{scl}.v", f"primitives.v"]]
+    else:
+        sources = [
+            proj_path / "../src/mmio/mmio.sv",
+            proj_path / "../src/mmio/sp_addr_handler.sv"
+        ]
 
     build_args = []
     if sim == "icarus":

--- a/cocotb/test_cache_interface.py
+++ b/cocotb/test_cache_interface.py
@@ -85,7 +85,10 @@ async def reset_dut(dut):
 async def collect_message(dut):
 
     logger = logging.getLogger("cocotb.test")
-    NUM_PINS = int(dut.NUM_TPINS.value)
+    if not gl:
+        NUM_PINS = int(dut.NUM_TPINS.value)
+    else:
+        NUM_PINS = 9
 
     while dut.req_o.value == 0:
         await RisingEdge(dut.clk_i)
@@ -105,7 +108,10 @@ async def collect_message(dut):
 async def send_message(dut, data, msg_len):
 
     logger = logging.getLogger("cocotb.test")
-    NUM_PINS = int(dut.NUM_RPINS.value)
+    if not gl:
+        NUM_PINS = int(dut.NUM_RPINS.value)
+    else:
+        NUM_PINS = 9
 
     dut.req_i.value = 1
 
@@ -146,7 +152,10 @@ class CycleCounter:
 # ─── Tests ────────────────────────────────────────────────────────────────────
 @cocotb.test
 async def test_send_BusRD(dut):
-    NUM_PINS = int(dut.NUM_TPINS.value)
+    if not gl:
+        NUM_PINS = int(dut.NUM_TPINS.value)
+    else:
+        NUM_PINS = 9
 
     await start_clock(dut)
     await reset_dut(dut)
@@ -174,7 +183,10 @@ async def test_send_BusRD(dut):
 
 @cocotb.test
 async def test_send_EvictDirty(dut):
-    NUM_PINS = int(dut.NUM_TPINS.value)
+    if not gl:
+        NUM_PINS = int(dut.NUM_TPINS.value)
+    else:
+        NUM_PINS = 9
 
     await start_clock(dut)
     await reset_dut(dut)
@@ -202,7 +214,10 @@ async def test_send_EvictDirty(dut):
 
 @cocotb.test
 async def test_send_SnoopBusRD_Ack(dut):
-    NUM_PINS = int(dut.NUM_TPINS.value)
+    if not gl:
+        NUM_PINS = int(dut.NUM_TPINS.value)
+    else:
+        NUM_PINS = 9
 
     await start_clock(dut)
     await reset_dut(dut)
@@ -230,7 +245,10 @@ async def test_send_SnoopBusRD_Ack(dut):
 
 @cocotb.test
 async def test_send_ResetDone(dut):
-    NUM_PINS = int(dut.NUM_TPINS.value)
+    if not gl:
+        NUM_PINS = int(dut.NUM_TPINS.value)
+    else:
+        NUM_PINS = 9
 
     await start_clock(dut)
     await reset_dut(dut)
@@ -406,25 +424,45 @@ async def test_receive_SnoopBusRDX(dut):
 def directory_interface_runner():
     proj_path = Path(__file__).resolve().parent
 
-    sources = [
-        proj_path / "../src/interposer_interface/cache_interface.sv",
-        proj_path / "../src/interposer_interface/rserializer.sv",
-        proj_path / "../src/interposer_interface/tserializer.sv",
-        proj_path / "../src/interposer_interface/lossy_pipe_stage.sv",
-    ]
+    sources = []
+    configs = []
+    if gl:
+        pdk_lib = os.path.join(
+            pdk_root, 
+            pdk, 
+            "libs.ref", 
+            scl, 
+            "verilog"
+        )
+        sources += [proj_path / f"../src/netlists/{hdl_toplevel}.nl.v"]
+        sources += [os.path.join(pdk_lib, f) for f in [f"{scl}.v", f"primitives.v"]]
 
-    configs = [
-        {"NUM_TPINS": 1, "NUM_RPINS": 1},
-        {"NUM_TPINS": 4, "NUM_RPINS": 4},
-        {"NUM_TPINS": 9, "NUM_RPINS": 9},
-    ]
+        configs += [
+            {"NUM_TPINS": 9, "NUM_RPINS": 9},
+        ]
+    else:
+        sources = [
+            proj_path / "../src/interposer_interface/cache_interface.sv",
+            proj_path / "../src/interposer_interface/rserializer.sv",
+            proj_path / "../src/interposer_interface/tserializer.sv",
+            proj_path / "../src/interposer_interface/lossy_pipe_stage.sv",
+        ]
+
+        configs += [
+            {"NUM_TPINS": 1, "NUM_RPINS": 1},
+            {"NUM_TPINS": 4, "NUM_RPINS": 4},
+            {"NUM_TPINS": 9, "NUM_RPINS": 9},
+        ]
 
     for config in configs:
         run_id = f"tp{config['NUM_TPINS']}_rp{config['NUM_RPINS']}"
 
         build_args = []
         if sim == "icarus":
-            build_args += ["-g2012", f"-P{hdl_toplevel}.NUM_TPINS={config['NUM_TPINS']}", f"-P{hdl_toplevel}.NUM_RPINS={config['NUM_RPINS']}"]
+            if not gl:
+                build_args += ["-g2012", f"-P{hdl_toplevel}.NUM_TPINS={config['NUM_TPINS']}", f"-P{hdl_toplevel}.NUM_RPINS={config['NUM_RPINS']}"]
+            else:
+                build_args += ["-g2012"]
         if sim == "verilator":
             build_args += ["--timing", "--trace", "--trace-fst", "--trace-structs", f"-GNUM_TPINS={config['NUM_TPINS']}", f"-GNUM_RPINS={config['NUM_RPINS']}"]
         

--- a/cocotb/test_directory_interface.py
+++ b/cocotb/test_directory_interface.py
@@ -88,7 +88,10 @@ async def reset_dut(dut):
 async def collect_message(dut):
 
     logger = logging.getLogger("cocotb.test")
-    NUM_PINS = int(dut.NUM_TPINS.value)
+    if not gl:
+        NUM_PINS = int(dut.NUM_TPINS.value)
+    else:
+        NUM_PINS = 9
 
     while dut.req_o.value == 0:
         await RisingEdge(dut.clk_i)
@@ -108,7 +111,10 @@ async def collect_message(dut):
 async def send_message(dut, data, msg_len):
 
     logger = logging.getLogger("cocotb.test")
-    NUM_PINS = int(dut.NUM_RPINS.value)
+    if not gl:
+        NUM_PINS = int(dut.NUM_RPINS.value)
+    else:
+        NUM_PINS = 9
 
     dut.req_i.value = 1
 
@@ -149,7 +155,10 @@ class CycleCounter:
 # ─── Tests ────────────────────────────────────────────────────────────────────
 @cocotb.test
 async def test_send_SnoopBusRD(dut):
-    NUM_PINS = int(dut.NUM_TPINS.value)
+    if not gl:
+        NUM_PINS = int(dut.NUM_TPINS.value)
+    else:
+        NUM_PINS = 9
 
     await start_clock(dut)
     await reset_dut(dut)
@@ -177,7 +186,10 @@ async def test_send_SnoopBusRD(dut):
 
 @cocotb.test
 async def test_send_BusRDX_Ack(dut):
-    NUM_PINS = int(dut.NUM_TPINS.value)
+    if not gl:
+        NUM_PINS = int(dut.NUM_TPINS.value)
+    else:
+        NUM_PINS = 9
 
     await start_clock(dut)
     await reset_dut(dut)
@@ -205,7 +217,10 @@ async def test_send_BusRDX_Ack(dut):
 
 @cocotb.test
 async def test_send_BusUPGR_Ack(dut):
-    NUM_PINS = int(dut.NUM_TPINS.value)
+    if not gl:
+        NUM_PINS = int(dut.NUM_TPINS.value)
+    else:
+        NUM_PINS = 9
 
     await start_clock(dut)
     await reset_dut(dut)
@@ -233,7 +248,10 @@ async def test_send_BusUPGR_Ack(dut):
 
 @cocotb.test
 async def test_send_WhoAmI(dut):
-    NUM_PINS = int(dut.NUM_TPINS.value)
+    if not gl:
+        NUM_PINS = int(dut.NUM_TPINS.value)
+    else:
+        NUM_PINS = 9
 
     await start_clock(dut)
     await reset_dut(dut)
@@ -422,25 +440,45 @@ async def test_receive_SnoopBusRD_Ack(dut):
 def directory_interface_runner():
     proj_path = Path(__file__).resolve().parent
 
-    sources = [
-        proj_path / "../src/interposer_interface/directory_interface.sv",
-        proj_path / "../src/interposer_interface/rserializer.sv",
-        proj_path / "../src/interposer_interface/tserializer.sv",
-        proj_path / "../src/interposer_interface/lossy_pipe_stage.sv",
-    ]
+    sources = []
+    configs = []
+    if gl:
+        pdk_lib = os.path.join(
+            pdk_root, 
+            pdk, 
+            "libs.ref", 
+            scl, 
+            "verilog"
+        )
+        sources += [proj_path / f"../src/netlists/{hdl_toplevel}.nl.v"]
+        sources += [os.path.join(pdk_lib, f) for f in [f"{scl}.v", f"primitives.v"]]
 
-    configs = [
-        {"NUM_TPINS": 1, "NUM_RPINS": 1},
-        {"NUM_TPINS": 4, "NUM_RPINS": 4},
-        {"NUM_TPINS": 9, "NUM_RPINS": 9},
-    ]
+        configs += [
+            {"NUM_TPINS": 9, "NUM_RPINS": 9},
+        ]
+    else:
+        sources = [
+            proj_path / "../src/interposer_interface/directory_interface.sv",
+            proj_path / "../src/interposer_interface/rserializer.sv",
+            proj_path / "../src/interposer_interface/tserializer.sv",
+            proj_path / "../src/interposer_interface/lossy_pipe_stage.sv",
+        ]
+
+        configs += [
+            {"NUM_TPINS": 1, "NUM_RPINS": 1},
+            {"NUM_TPINS": 4, "NUM_RPINS": 4},
+            {"NUM_TPINS": 9, "NUM_RPINS": 9},
+        ]
 
     for config in configs:
         run_id = f"tp{config['NUM_TPINS']}_rp{config['NUM_RPINS']}"
 
         build_args = []
         if sim == "icarus":
-            build_args += ["-g2012", f"-P{hdl_toplevel}.NUM_TPINS={config['NUM_TPINS']}", f"-P{hdl_toplevel}.NUM_RPINS={config['NUM_RPINS']}"]
+            if not gl:
+                build_args += ["-g2012", f"-P{hdl_toplevel}.NUM_TPINS={config['NUM_TPINS']}", f"-P{hdl_toplevel}.NUM_RPINS={config['NUM_RPINS']}"]
+            else:
+                build_args += ["-g2012"]
         if sim == "verilator":
             build_args += ["--timing", "--trace", "--trace-fst", "--trace-structs", f"-GNUM_TPINS={config['NUM_TPINS']}", f"-GNUM_RPINS={config['NUM_RPINS']}"]
         

--- a/cocotb/test_rserializer.py
+++ b/cocotb/test_rserializer.py
@@ -303,15 +303,32 @@ async def test_valid_o_new_msg(dut):
 def rserializer_runner():
     proj_path = Path(__file__).resolve().parent
 
-    sources = [
-        proj_path / "../src/interposer_interface/rserializer.sv",
-    ]
+    sources = []
+    configs = []
+    if gl:
+        pdk_lib = os.path.join(
+            pdk_root, 
+            pdk, 
+            "libs.ref", 
+            scl, 
+            "verilog"
+        )
+        sources += [proj_path / f"../src/netlists/{hdl_toplevel}.nl.v"]
+        sources += [os.path.join(pdk_lib, f) for f in [f"{scl}.v", f"primitives.v"]]
 
-    configs = [
-        {"NUM_PINS": 1},
-        {"NUM_PINS": 4},
-        {"NUM_PINS": 9},
-    ]
+        configs += [
+            {"NUM_PINS": 9},
+        ]
+    else:
+        sources += [
+            proj_path / "../src/interposer_interface/rserializer.sv",
+        ]
+
+        configs += [
+            {"NUM_PINS": 1},
+            {"NUM_PINS": 4},
+            {"NUM_PINS": 9},
+        ]
 
     for config in configs:
         run_id = f"p{config['NUM_PINS']}"

--- a/cocotb/test_tserializer.py
+++ b/cocotb/test_tserializer.py
@@ -428,16 +428,32 @@ async def test_multi_spaced_send(dut):
 def tserializer_runner():
     proj_path = Path(__file__).resolve().parent
 
-    sources = [
-        proj_path / "../src/interposer_interface/tserializer.sv",
-    ]
+    sources = []
+    configs = []
+    if gl:
+        pdk_lib = os.path.join(
+            pdk_root, 
+            pdk, 
+            "libs.ref", 
+            scl, 
+            "verilog"
+        )
+        sources += [proj_path / f"../src/netlists/{hdl_toplevel}.nl.v"]
+        sources += [os.path.join(pdk_lib, f) for f in [f"{scl}.v", f"primitives.v"]]
 
-    configs = [
-        {"NUM_PINS": 1},
-        {"NUM_PINS": 4},
-        {"NUM_PINS": 9},
-    ]
+        configs += [
+            {"NUM_PINS": 9},
+        ]
+    else:
+        sources += [
+            proj_path / "../src/interposer_interface/tserializer.sv",
+        ]
 
+        configs += [
+            {"NUM_PINS": 1},
+            {"NUM_PINS": 4},
+            {"NUM_PINS": 9},
+        ]
     for config in configs:
         run_id = f"p{config['NUM_PINS']}"
 

--- a/cocotb/wrr_arbiter_test.py
+++ b/cocotb/wrr_arbiter_test.py
@@ -465,9 +465,20 @@ async def test_reset_clears_pointer_and_resumes(dut):
 def wrr_arbiter_runner():
     proj_path = Path(__file__).resolve().parent
 
-    sources = [
-        proj_path / "../src/arb/wrr_arbiter.sv",
-    ]
+    if gl:
+        pdk_lib = os.path.join(
+            pdk_root, 
+            pdk, 
+            "libs.ref", 
+            scl, 
+            "verilog"
+        )
+        sources += [proj_path / f"../src/netlists/{hdl_toplevel}.nl.v"]
+        sources += [os.path.join(pdk_lib, f) for f in [f"{scl}.v", f"primitives.v"]]
+    else:
+        sources = [
+            proj_path / "../src/arb/wrr_arbiter.sv",
+        ]
 
     build_args = []
     if sim == "icarus":

--- a/librelane/config.yaml
+++ b/librelane/config.yaml
@@ -32,10 +32,9 @@ VERILOG_FILES:
 - dir::../src/housekeeping/boot_fsm.sv
 - dir::../src/housekeeping/housekeeping_top.sv
 - dir::../src/housekeeping/spi_engine.sv
-- dir::../src/mem_ctrl/mem2048x32.sv
-- dir::../src/mem_ctrl/mem512x32.sv
-- dir::../src/msi_protocol/msi.v
-- dir::../src/msi_protocol/msi_v2.sv
+- dir::../src/mem_ctrl/main_memory/mem2048x32.sv
+- dir::../src/mem_ctrl/main_memory/mem512x32.sv
+- dir::../src/msi_protocol/msi_protocol.sv
 - dir::../src/interposer_interface/cache_interface.sv
 - dir::../src/interposer_interface/directory_interface.sv
 - dir::../src/interposer_interface/lossy_pipe_stage.sv

--- a/scripts/gen_netlists.json
+++ b/scripts/gen_netlists.json
@@ -1,0 +1,13 @@
+{
+  "target_modules": [
+    "wrr_arbiter",
+    "housekeeping_top",
+    "mem_ctrl_2048x32",
+    "mem_ctrl_128x32",
+    "sp_addr_handler",
+    "cache_interface",
+    "directory_interface",
+    "rserializer",
+    "tserializer"
+  ]
+}

--- a/scripts/gen_netlists.py
+++ b/scripts/gen_netlists.py
@@ -1,0 +1,91 @@
+import glob
+import subprocess
+import os
+import shutil
+from pathlib import Path
+import json
+
+def prepend_timescale(file_path, timescale="`timescale 1ns/1ps"):
+    """Prepends a timescale directive to the top of a file."""
+    with open(file_path, 'r') as f:
+        content = f.read()
+    
+    # Avoid double-adding if the script is run multiple times
+    if not content.strip().startswith("`timescale"):
+        with open(file_path, 'w') as f:
+            f.write(f"{timescale}\n{content}")
+        print(f"    Timescale added to {os.path.basename(file_path)}")
+
+pdk_root = os.getenv("PDK_ROOT", Path("~/.ciel").expanduser())
+pdk = os.getenv("PDK", "gf180mcuD")
+slot = os.getenv("SLOT", "1x1")
+project_root = Path(__file__).parent.parent.resolve()
+
+# 1. Collect all SystemVerilog files
+# Put packages or global defines first to satisfy SV requirements
+all_files = glob.glob("**/*.sv", recursive=True)
+all_files += [Path(pdk_root) / pdk / "libs.ref/gf180mcu_fd_ip_sram/verilog/gf180mcu_fd_ip_sram__sram64x8m8wm1.v"]
+
+# Remove duplicates while preserving order
+all_files = list(dict.fromkeys(all_files))
+all_files_abs = [os.path.abspath(os.path.join(project_root, f)) for f in all_files]
+
+base_config = "librelane/config.yaml"
+# Your list of top-level modules to generate netlists for
+with open(Path(project_root) / 'scripts' / 'gen_netlists.json', 'r') as f:
+    data = json.load(f)
+
+# 2. Extract the list into a variable
+target_modules = data["target_modules"]
+
+
+for design in target_modules:
+    print(f"--- Synthesizing {design} with full file list ---")
+    
+    files_str = str(all_files_abs).replace("[", "").replace("]", "").replace("'", "").replace(" ", "")
+
+    cmd = [
+        "python3", "-m", "librelane", 
+        f"librelane/slots/slot_{slot}.yaml", base_config,
+        "--pdk-root", pdk_root,
+        "--pdk", pdk, "--manual-pdk",
+        "--override-config", f"DESIGN_NAME={design}",
+        "--override-config", f"VERILOG_FILES={files_str}",
+        "--to", "Yosys.Synthesis"
+    ]
+    
+    try:
+        subprocess.run(cmd, check=True)
+        print(f"\n    Finished {design} successfully.")
+        
+        dest_dir = project_root / "src" / "netlists"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+        runs_dir = project_root / "librelane" / "runs"
+
+        if runs_dir.exists():
+            # Get all subdirectories in 'runs', sorted by creation time (newest first)
+            all_runs = sorted(
+                [d for d in runs_dir.iterdir() if d.is_dir()],
+                key=lambda x: x.stat().st_mtime,
+                reverse=True
+            )
+
+            if all_runs:
+                current_run_dir = all_runs[0]
+                result_path = current_run_dir / "final" / "nl" / f"{design}.nl.v"
+                
+                if result_path.exists():
+                    dest_file = dest_dir / f"{design}.nl.v"
+                    shutil.copy2(result_path, dest_file)
+                    prepend_timescale(dest_file)
+                    print(f"    Netlist captured from: {current_run_dir.name}")
+                else:
+                    print(f"    Warning: .nl.v file missing in {current_run_dir}")
+            else:
+                print(f"    Warning: No run directories found in {runs_dir}")
+        else:
+            print(f"    Warning: Runs directory does not exist for {design}")
+    except subprocess.CalledProcessError as e:
+        print(f"\n  Error: Synthesis failed for {design}.")
+        # The logs are saved in the run directory if it fails

--- a/src/cache/rishi_stuff/cache_controller.sv
+++ b/src/cache/rishi_stuff/cache_controller.sv
@@ -85,23 +85,6 @@ module cache_controller #(
     assign hit0 = valid_q[0][set_idx] && (tag_q[0][set_idx] == tag_in) && (msi_q[0][set_idx] != MSI_I);
     assign hit1 = valid_q[1][set_idx] && (tag_q[1][set_idx] == tag_in) && (msi_q[1][set_idx] != MSI_I);
 
-    cache #(.NUM_SETS(NUM_SETS), .WORDS_PER_LINE(WORDS_PER_LINE), .USE_BEHAVIORAL(USE_BEHAVIORAL_WAYS)) u_way0 (
-        .clk_i(clk_i), .rst_ni(rst_ni),
-        .rd_en_i(rd_en_way[0]), .rd_set_i(set_idx), .rd_word_i(word_off), .rd_data_o(way_rdata[0]),
-        .wr_en_i(wr_en_way[0]), .wr_set_i(wr_set_way[0]), .wr_word_i(wr_word_way[0]), .wr_data_i(wr_data_way[0]), .wr_strb_i(wr_strb_way[0])
-    );
-    cache #(.NUM_SETS(NUM_SETS), .WORDS_PER_LINE(WORDS_PER_LINE), .USE_BEHAVIORAL(USE_BEHAVIORAL_WAYS)) u_way1 (
-        .clk_i(clk_i), .rst_ni(rst_ni),
-        .rd_en_i(rd_en_way[1]), .rd_set_i(set_idx), .rd_word_i(word_off), .rd_data_o(way_rdata[1]),
-        .wr_en_i(wr_en_way[1]), .wr_set_i(wr_set_way[1]), .wr_word_i(wr_word_way[1]), .wr_data_i(wr_data_way[1]), .wr_strb_i(wr_strb_way[1])
-    );
-
-    mem_ctrl_512x32 u_backing_mem (
-        .clk_i(clk_i), .rst_ni(rst_ni),
-        .mem_valid_i(backing_valid_q), .mem_instr_i(1'b0), .mem_addr_i(backing_addr_q), .mem_wdata_i(backing_wdata_q), .mem_wstrb_i(backing_wstrb_q),
-        .mem_rdata_o(backing_rdata), .mem_ready_o(backing_ready)
-    );
-
     logic        backing_valid_q;
     logic [31:0] backing_addr_q;
     logic [31:0] backing_wdata_q;
@@ -122,6 +105,23 @@ module cache_controller #(
     logic [3:0]  pending_meta_q;
     logic [31:0] pending_addr_q;
     logic [31:0] pending_wdata_q;
+
+    cache #(.NUM_SETS(NUM_SETS), .WORDS_PER_LINE(WORDS_PER_LINE), .USE_BEHAVIORAL(USE_BEHAVIORAL_WAYS)) u_way0 (
+        .clk_i(clk_i), .rst_ni(rst_ni),
+        .rd_en_i(rd_en_way[0]), .rd_set_i(set_idx), .rd_word_i(word_off), .rd_data_o(way_rdata[0]),
+        .wr_en_i(wr_en_way[0]), .wr_set_i(wr_set_way[0]), .wr_word_i(wr_word_way[0]), .wr_data_i(wr_data_way[0]), .wr_strb_i(wr_strb_way[0])
+    );
+    cache #(.NUM_SETS(NUM_SETS), .WORDS_PER_LINE(WORDS_PER_LINE), .USE_BEHAVIORAL(USE_BEHAVIORAL_WAYS)) u_way1 (
+        .clk_i(clk_i), .rst_ni(rst_ni),
+        .rd_en_i(rd_en_way[1]), .rd_set_i(set_idx), .rd_word_i(word_off), .rd_data_o(way_rdata[1]),
+        .wr_en_i(wr_en_way[1]), .wr_set_i(wr_set_way[1]), .wr_word_i(wr_word_way[1]), .wr_data_i(wr_data_way[1]), .wr_strb_i(wr_strb_way[1])
+    );
+
+    mem_ctrl_512x32 u_backing_mem (
+        .clk_i(clk_i), .rst_ni(rst_ni),
+        .mem_valid_i(backing_valid_q), .mem_instr_i(1'b0), .mem_addr_i(backing_addr_q), .mem_wdata_i(backing_wdata_q), .mem_wstrb_i(backing_wstrb_q),
+        .mem_rdata_o(backing_rdata), .mem_ready_o(backing_ready)
+    );
 
     integer s, w;
 

--- a/src/interposer_interface/cache_interface.sv
+++ b/src/interposer_interface/cache_interface.sv
@@ -1,8 +1,8 @@
 `timescale 1ns/1ps
 
 module cache_interface #(
-    parameter int NUM_TPINS = 1,
-    parameter int NUM_RPINS = 1
+    parameter int NUM_TPINS = 9,
+    parameter int NUM_RPINS = 9
 )
 (
     input  logic                clk_i,

--- a/src/interposer_interface/directory_interface.sv
+++ b/src/interposer_interface/directory_interface.sv
@@ -1,8 +1,8 @@
 `timescale 1ns/1ps
 
 module directory_interface #(
-    parameter int NUM_TPINS = 1,
-    parameter int NUM_RPINS = 1
+    parameter int NUM_TPINS = 9,
+    parameter int NUM_RPINS = 9
 )
 (
     input  logic                clk_i,

--- a/src/interposer_interface/rserializer.sv
+++ b/src/interposer_interface/rserializer.sv
@@ -1,7 +1,7 @@
 `timescale 1ns/1ps
 
 module rserializer #(
-    parameter int NUM_PINS = 1,
+    parameter int NUM_PINS = 9,
     parameter int MAX_MSG_LEN = 68
 )(
 

--- a/src/interposer_interface/tserializer.sv
+++ b/src/interposer_interface/tserializer.sv
@@ -1,7 +1,7 @@
 `timescale 1ns/1ps
 
 module tserializer #(
-    parameter int NUM_PINS = 1,
+    parameter int NUM_PINS = 9,
     parameter int MAX_MSG_LEN = 68,
     parameter int MSG_LEN_0 = 4,
     parameter int MSG_LEN_1 = 12,


### PR DESCRIPTION
When running cocotb tests, set envvar GL=True to test gatelevel netlists

- Edited test scripts to handle gatelevel netlists.
- Created script to generate netlists, move them to /src, and prep them for simulation
- To add another module to the gen_netlist, add it to gen_netlist.json in /scripts
-  Changed default num_pins on all serial interfaces to 9 since that's what we're using